### PR TITLE
Remove recursive flag from rm

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -33,28 +33,28 @@ sleep 5
 
 echo ' '
 echo 'Removing current nvidia prime setup if applicable, file not found can be ignored......'
-rm -rf /etc/X11/mhwd.d/nvidia.conf
-rm -rf /etc/X11/mhwd.d/nvidia.conf.nvidia-xconfig-original
-rm -rf /usr/share/sddm/scripts/Xsetup
-echo 'rm -rf /etc/X11/mhwd.d/nvidia.conf*'
-rm -rf /etc/X11/xorg.conf.d/90-mhwd.conf
-rm -rf /etc/X11/xorg.conf.d/20-intel.conf
-rm -rf /etc/X11/xorg.conf.d/20-amdgpu.conf
-rm -rf /etc/X11/xorg.conf.d/nvidia.conf
-rm -rf /etc/X11/xorg.conf.d/optimus.conf
-echo 'rm -rf /etc/X11/xorg.conf.d/90-mhwd.conf'
-rm -rf /etc/modprobe.d/mhwd-gpu.conf
-rm -rf /etc/modprobe.d/optimus.conf
-rm -rf /etc/modprobe.d/nvidia.conf
-echo 'rm -rf /etc/modprobe.d/mhwd-gpu.conf'
-rm -rf /etc/modprobe.d/nvidia-drm.conf
-rm -rf /etc/modprobe.d/nvidia.conf
-echo 'rm -rf /etc/modprobe.d/nvidia*.conf'
-rm -rf /etc/modules-load.d/mhwd-gpu.conf
-echo 'rm -rf /etc/modules-load.d/mhwd-gpu.conf'
-rm -rf /usr/local/bin/optimus.sh
-rm -rf /usr/local/share/optimus.desktop
-echo 'rm -rf /usr/local/share/optimus.desktop'
+rm -f /etc/X11/mhwd.d/nvidia.conf
+rm -f /etc/X11/mhwd.d/nvidia.conf.nvidia-xconfig-original
+rm -f /usr/share/sddm/scripts/Xsetup
+echo 'rm -f /etc/X11/mhwd.d/nvidia.conf*'
+rm -f /etc/X11/xorg.conf.d/90-mhwd.conf
+rm -f /etc/X11/xorg.conf.d/20-intel.conf
+rm -f /etc/X11/xorg.conf.d/20-amdgpu.conf
+rm -f /etc/X11/xorg.conf.d/nvidia.conf
+rm -f /etc/X11/xorg.conf.d/optimus.conf
+echo 'rm -f /etc/X11/xorg.conf.d/90-mhwd.conf'
+rm -f /etc/modprobe.d/mhwd-gpu.conf
+rm -f /etc/modprobe.d/optimus.conf
+rm -f /etc/modprobe.d/nvidia.conf
+echo 'rm -f /etc/modprobe.d/mhwd-gpu.conf'
+rm -f /etc/modprobe.d/nvidia-drm.conf
+rm -f /etc/modprobe.d/nvidia.conf
+echo 'rm -f /etc/modprobe.d/nvidia*.conf'
+rm -f /etc/modules-load.d/mhwd-gpu.conf
+echo 'rm -f /etc/modules-load.d/mhwd-gpu.conf'
+rm -f /usr/local/bin/optimus.sh
+rm -f /usr/local/share/optimus.desktop
+echo 'rm -f /usr/local/share/optimus.desktop'
 sleep 2
 
 echo 'Copying contents of ~/optimus-switch-amd-sddm/* to /etc/ .......'

--- a/switch-uninstall.sh
+++ b/switch-uninstall.sh
@@ -9,27 +9,27 @@ fi
 
 echo 'Removing optimus-switch'
 
-rm -rf /usr/local/bin/set-amd.sh
-rm -rf /usr/local/bin/set-nvidia.sh
-rm -rf /usr/local/bin/optimus.sh
-rm -rf /usr/share/sddm/scripts/Xsetup
-rm -rf /etc/switch
+rm -f /usr/local/bin/set-amd.sh
+rm -f /usr/local/bin/set-nvidia.sh
+rm -f /usr/local/bin/optimus.sh
+rm -f /usr/share/sddm/scripts/Xsetup
+rm -f /etc/switch
 
 systemctl disable disable-nvidia.service
-rm -rf /etc/systemd/system/disable-nvidia.service
+rm -f /etc/systemd/system/disable-nvidia.service
 
-rm -rf /etc/X11/mhwd.d/99-nvidia.conf
-rm -rf /etc/X11/xorg.conf.d/99-nvidia.conf
-rm -rf /etc/modprobe.d/99-nvidia.conf
-rm -rf /etc/modules-load.d/99-nvidia.conf
+rm -f /etc/X11/mhwd.d/99-nvidia.conf
+rm -f /etc/X11/xorg.conf.d/99-nvidia.conf
+rm -f /etc/modprobe.d/99-nvidia.conf
+rm -f /etc/modules-load.d/99-nvidia.conf
 
-rm -rf /etc/X11/xorg.conf.d/99-amd.conf
-rm -rf /etc/modprobe.d/99-amd.conf
-rm -rf /etc/modules-load.d/99-amd.conf
+rm -f /etc/X11/xorg.conf.d/99-amd.conf
+rm -f /etc/modprobe.d/99-amd.conf
+rm -f /etc/modules-load.d/99-amd.conf
 
 sleep 1
 echo 'optimus-switch is now uninstalled'
 echo '########'
 echo 'if you reboot now, you will not have a working Xorg setup.'
 echo 'setup another optimus solution before rebooting.'
-rm -rf uninstall-switch.sh 
+rm -f uninstall-switch.sh 

--- a/switch/set-amd.sh
+++ b/switch/set-amd.sh
@@ -5,10 +5,10 @@
 #with modeset.xorg.conf on the line below.
 echo 'Removing nvidia prime setup......'
 
-rm -rf /etc/X11/xorg.conf.d/99-nvidia.conf
-rm -rf /etc/modprobe.d/99-nvidia.conf
-rm -rf /etc/modules-load.d/99-nvidia.conf
-rm -rf /usr/share/sddm/scripts/Xsetup
+rm -f /etc/X11/xorg.conf.d/99-nvidia.conf
+rm -f /etc/modprobe.d/99-nvidia.conf
+rm -f /etc/modules-load.d/99-nvidia.conf
+rm -f /usr/share/sddm/scripts/Xsetup
 
 sleep 1
 echo 'Setting amd only mode.......'

--- a/switch/set-nvidia.sh
+++ b/switch/set-nvidia.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 echo 'Removing amd only mode setup......'
-rm -rf /etc/X11/xorg.conf.d/99-amd.conf
-rm -rf /etc/modprobe.d/99-amd.conf
-rm -rf /etc/modules-load.d/99-amd.conf
-rm -rf /usr/share/sddm/scripts/Xsetup
+rm -f /etc/X11/xorg.conf.d/99-amd.conf
+rm -f /etc/modprobe.d/99-amd.conf
+rm -f /etc/modules-load.d/99-amd.conf
+rm -f /usr/share/sddm/scripts/Xsetup
 
 sleep 1
 echo 'Setting nvidia prime mode.......'


### PR DESCRIPTION
Hi buddy,

First of all I would like to thank you for this neat repo.

I am opening this PR that removes the recursive flag from rm command. I've checked the code and there is nothing wrong but the reasons I did the change in the forked repo and thought of sharing it with you in case you wish to apply it also are:

- A future change (if you plan to do any) is prone to human eye error, e.g. `rm -rf /etc/ some/path`
- You are only deleting files most of the time, implicity like /path/to/file or with wildcards like /path/to/file* and therefore recursive flag does not add any value but only the danger of running it with force as root
- It makes people nervous just by reading it :P

anw kudos and thanks again!
